### PR TITLE
Remove email_domains and make optional tenant_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,10 @@ provider "okta" {
 
 module "cyral-idp-okta" {
   source = "cyralinc/idp-okta/cyral"
-  version = "1.0.0"
+  version = ">= 2.0.0"
 
   control_plane = "mytenant.cyral.com:8000"
-  tenant = "mytenant"
   integration_name = "Okta SSO"
-  email_domains = ["mydomain.com"]
 
   okta_app_name = "Cyral"
   okta_groups = ["Everyone"]
@@ -80,7 +78,6 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_control_plane"></a> [control\_plane](#input\_control\_plane) | Control plane host and API port (ex: some-cp.cyral.com:8000) | `string` | n/a | yes |
-| <a name="input_email_domains"></a> [email\_domains](#input\_email\_domains) | Email domains that will be accepted as valid logins. | `list(string)` | `[]` | no |
 | <a name="input_integration_name"></a> [integration\_name](#input\_integration\_name) | Integration name that will be shown in Control Plane. | `string` | n/a | yes |
 | <a name="input_okta_app_name"></a> [okta\_app\_name](#input\_okta\_app\_name) | The name of the app that will be created in Okta. | `string` | n/a | yes |
 | <a name="input_okta_groups"></a> [okta\_groups](#input\_okta\_groups) | Groups that the cyral app will be assigned to in Okta. | `list(string)` | `[]` | no |

--- a/main.tf
+++ b/main.tf
@@ -17,8 +17,6 @@ resource "cyral_integration_okta" "this" {
   name = var.integration_name
 
   certificate = okta_app_saml.this.certificate
-
-  email_domains = var.email_domains
 }
 
 data "okta_group" "this" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,17 +1,12 @@
 variable "tenant" {
   type = string
   description = "Tenant associated with the control plane"
+  default = "default"
 }
 
 variable "control_plane" {
   type = string
   description = "Control plane host and API port (ex: some-cp.cyral.com:8000)"
-}
-
-variable "email_domains" {
-  type = list(string)
-  description = "Email domains that will be accepted as valid logins."
-  default = []
 }
 
 variable "integration_name" {


### PR DESCRIPTION
`email_domains` are not required anymore and `tenant_name` should be optional and set as `default` if it is not provided.

Fix #2 