### PR TITLE
ENG-6816: Deprecate IDP Okta Module

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This module provides the complete configuration to integrate Okta as an Identity Provider to Cyral Control Plane. It applies an equivalent configuration as described in the [Cyral documentation for Okta SSO](https://cyral.com/docs/sso-okta).
 
+~> **Warning:** This module was deprecated, please consider using the [SSO Okta Module](https://registry.terraform.io/modules/cyralinc/sso-okta/cyral/latest) instead.
+
 ## Usage
 
 ```terraform


### PR DESCRIPTION
## Description of the change
This PR deprecates the actual IDP Okta Module so that the new [SSO Okta Module](https://github.com/cyralinc/terraform-cyral-idp-okta/pull/7) can replace this one.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Jira issue referenced in commit message and/or PR title

### Testing
Tested through manual Terraform configuration.