### PR TITLE
ENG-7044: Add a parameter to control Okta filters for groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ No modules.
 | <a name="input_idp_integration_name"></a> [idp\_integration\_name](#input\_idp\_integration\_name) | IdP integration name that will be shown in Control Plane. | `string` | n/a | yes |
 | <a name="input_okta_app_name"></a> [okta\_app\_name](#input\_okta\_app\_name) | The name of the Okta Application that will be created. | `string` | n/a | yes |
 | <a name="input_okta_groups"></a> [okta\_groups](#input\_okta\_groups) | Groups that will be assigned in the Okta Application. | `list(string)` | `[]` | no |
+| <a name="input_okta_groups_filter"></a> [okta\_groups\_filter](#input\_okta\_groups\_filter) | The type and value of the filter that will be applied to Okta groups. | <pre>object({<br>    type = string<br>    value = string<br>  })</pre> | <pre>{<br>  "type": "REGEX",<br>  "value": ".*"<br>}</pre> | no |
 | <a name="input_tenant"></a> [tenant](#input\_tenant) | Tenant associated with the Control Plane. | `string` | `"default"` | no |
 | <a name="input_wants_assertions_encrypted"></a> [wants\_assertions\_encrypted](#input\_wants\_assertions\_encrypted) | Indicates whether the Cyral Service Provider expects an encrypted assertion. | `bool` | If not set, the default value will be retrieved from the Okta Application SAML metadata. | no |
 

--- a/examples/full-config/main.tf
+++ b/examples/full-config/main.tf
@@ -22,6 +22,10 @@ module "cyral_idp_okta" {
   
   okta_app_name = "Cyral"
   okta_groups = ["Everyone"]
+  okta_groups_filter = {
+    type = "REGEX"
+    value = "(Dev)|(Admin)"
+  }
 
   idp_integration_name = "Okta"
   back_channel_logout = false

--- a/main.tf
+++ b/main.tf
@@ -62,8 +62,8 @@ resource "okta_app_saml" "this" {
   attribute_statements {
     name = "groups"
     type = "GROUP"
-    filter_type = "REGEX"
-    filter_value = ".*"
+    filter_type = var.okta_groups_filter.type
+    filter_value = var.okta_groups_filter.value
     values = []
     namespace = "urn:oasis:names:tc:SAML:2.0:attrname-format:basic"
   }

--- a/variables.tf
+++ b/variables.tf
@@ -48,3 +48,15 @@ variable "okta_app_name" {
   type = string
   description = "The name of the Okta Application that will be created."
 }
+
+variable "okta_groups_filter" {
+  type = object({
+    type = string
+    value = string
+  })
+  description = "The type and value of the filter that will be applied to Okta groups."
+  default = {
+    type = "REGEX"
+    value = ".*"
+  }
+}


### PR DESCRIPTION
## Description of the change
This PR updates the `IdP Okta` module with a new variable that allows configuring the Okta groups filter.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Jira issue referenced in commit message and/or PR title

### Testing
Tested through manual Terraform configuration and running the module examples.