### PR TITLE
 ENG-7829: Fix extra bracket around userName for subject_name_id_template

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -23,7 +23,7 @@ resource "okta_app_saml" "this" {
   recipient = local.single_sign_on_url
   destination = local.single_sign_on_url
   audience = local.audience_restriction
-  subject_name_id_template = "$${{user.userName}}"
+  subject_name_id_template = "$${user.userName}"
   subject_name_id_format = "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"
   response_signed = true
   signature_algorithm = "RSA_SHA256"


### PR DESCRIPTION
Our implementation was using this:
`subject_name_id_template = "$${{user.userName}}"`

the okta terraform [doc](https://registry.terraform.io/providers/okta/okta/latest/docs/resources/app_saml) shows this is the correct form:
```yaml
resource "okta_app_saml" "example" {
  label                    = "example"
  sso_url                  = "https://example.com"
  recipient                = "https://example.com"
  destination              = "https://example.com"
  audience                 = "https://example.com/audience"
  subject_name_id_template = "$${user.userName}"
```

The side effect is that the username imported through SAML had an extra square bracket around it, which is incorrect and not desirable