### PR TITLE
ENG-8908: Pin Okta Provider version to <= 3.30.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .terraform
 .terraform.lock.hcl
 terraform.tfstate*
+
+# Folder to manually test the module
+test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## 3.0.3 - (July 12, 2022)
+
+Minimum required Control Plane version: `v2.25.0`.
+
+### Bug fix:
+
+* Pin Okta Provider version to `<= 3.30.0` ([#15](https://github.com/cyralinc/terraform-okta-idp/pull/15))
+
+
 ## 3.0.2 - (June 21, 2022)
 
 Minimum required Control Plane version: `v2.25.0`.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ terraform {
   required_providers {
     okta = {
       source = "okta/okta"
-      version = "~> 3.17"
+      version = "3.30.0"
     }
     cyral = {
       source = "cyralinc/cyral"
@@ -67,7 +67,7 @@ output "okta_app_saml_id" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_cyral"></a> [cyral](#requirement\_cyral) | >= 2.2.0 |
-| <a name="requirement_okta"></a> [okta](#requirement\_okta) | ~> 3.17 |
+| <a name="requirement_okta"></a> [okta](#requirement\_okta) | 3.30.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.1.0 |
 
 ## Providers
@@ -75,7 +75,7 @@ output "okta_app_saml_id" {
 | Name | Version |
 |------|---------|
 | <a name="provider_cyral"></a> [cyral](#provider\_cyral) | >= 2.2.0 |
-| <a name="provider_okta"></a> [okta](#provider\_okta) | ~> 3.17 |
+| <a name="provider_okta"></a> [okta](#provider\_okta) | 3.30.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.1.0 |
 
 ## Modules
@@ -87,12 +87,12 @@ No modules.
 | Name | Type |
 |------|------|
 | [cyral_integration_idp_okta.this](https://registry.terraform.io/providers/cyralinc/cyral/latest/docs/resources/integration_idp_okta) | resource |
-| [okta_app_group_assignments.this](https://registry.terraform.io/providers/okta/okta/latest/docs/resources/app_group_assignments) | resource |
-| [okta_app_saml.this](https://registry.terraform.io/providers/okta/okta/latest/docs/resources/app_saml) | resource |
+| [okta_app_group_assignments.this](https://registry.terraform.io/providers/okta/okta/3.30.0/docs/resources/app_group_assignments) | resource |
+| [okta_app_saml.this](https://registry.terraform.io/providers/okta/okta/3.30.0/docs/resources/app_saml) | resource |
 | [random_uuid.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/uuid) | resource |
 | [cyral_saml_certificate.this](https://registry.terraform.io/providers/cyralinc/cyral/latest/docs/data-sources/saml_certificate) | data source |
 | [cyral_saml_configuration.this](https://registry.terraform.io/providers/cyralinc/cyral/latest/docs/data-sources/saml_configuration) | data source |
-| [okta_group.this](https://registry.terraform.io/providers/okta/okta/latest/docs/data-sources/group) | data source |
+| [okta_group.this](https://registry.terraform.io/providers/okta/okta/3.30.0/docs/data-sources/group) | data source |
 
 ## Inputs
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ terraform {
   required_providers {
     okta = {
       source = "okta/okta"
-      version = "3.30.0"
+      version = "~> 3.17, <= 3.30.0"
     }
     cyral = {
       source = "cyralinc/cyral"
@@ -67,7 +67,7 @@ output "okta_app_saml_id" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_cyral"></a> [cyral](#requirement\_cyral) | >= 2.2.0 |
-| <a name="requirement_okta"></a> [okta](#requirement\_okta) | 3.30.0 |
+| <a name="requirement_okta"></a> [okta](#requirement\_okta) | ~> 3.17, <= 3.30.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.1.0 |
 
 ## Providers
@@ -75,7 +75,7 @@ output "okta_app_saml_id" {
 | Name | Version |
 |------|---------|
 | <a name="provider_cyral"></a> [cyral](#provider\_cyral) | >= 2.2.0 |
-| <a name="provider_okta"></a> [okta](#provider\_okta) | 3.30.0 |
+| <a name="provider_okta"></a> [okta](#provider\_okta) | ~> 3.17, <= 3.30.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.1.0 |
 
 ## Modules
@@ -87,12 +87,12 @@ No modules.
 | Name | Type |
 |------|------|
 | [cyral_integration_idp_okta.this](https://registry.terraform.io/providers/cyralinc/cyral/latest/docs/resources/integration_idp_okta) | resource |
-| [okta_app_group_assignments.this](https://registry.terraform.io/providers/okta/okta/3.30.0/docs/resources/app_group_assignments) | resource |
-| [okta_app_saml.this](https://registry.terraform.io/providers/okta/okta/3.30.0/docs/resources/app_saml) | resource |
+| [okta_app_group_assignments.this](https://registry.terraform.io/providers/okta/okta/latest/docs/resources/app_group_assignments) | resource |
+| [okta_app_saml.this](https://registry.terraform.io/providers/okta/okta/latest/docs/resources/app_saml) | resource |
 | [random_uuid.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/uuid) | resource |
 | [cyral_saml_certificate.this](https://registry.terraform.io/providers/cyralinc/cyral/latest/docs/data-sources/saml_certificate) | data source |
 | [cyral_saml_configuration.this](https://registry.terraform.io/providers/cyralinc/cyral/latest/docs/data-sources/saml_configuration) | data source |
-| [okta_group.this](https://registry.terraform.io/providers/okta/okta/3.30.0/docs/data-sources/group) | data source |
+| [okta_group.this](https://registry.terraform.io/providers/okta/okta/latest/docs/data-sources/group) | data source |
 
 ## Inputs
 

--- a/examples/basic-config/versions.tf
+++ b/examples/basic-config/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     okta = {
       source = "okta/okta"
-      version = "3.30.0"
+      version = "~> 3.17, <= 3.30.0"
     }
     cyral = {
       source = "cyralinc/cyral"

--- a/examples/basic-config/versions.tf
+++ b/examples/basic-config/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     okta = {
       source = "okta/okta"
-      version = "~> 3.17"
+      version = "3.30.0"
     }
     cyral = {
       source = "cyralinc/cyral"

--- a/examples/full-config/versions.tf
+++ b/examples/full-config/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     okta = {
       source = "okta/okta"
-      version = "3.30.0"
+      version = "~> 3.17, <= 3.30.0"
     }
     cyral = {
       source = "cyralinc/cyral"

--- a/examples/full-config/versions.tf
+++ b/examples/full-config/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     okta = {
       source = "okta/okta"
-      version = "~> 3.17"
+      version = "3.30.0"
     }
     cyral = {
       source = "cyralinc/cyral"

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     okta = {
       source = "okta/okta"
-      version = "~> 3.17"
+      version = "3.30.0"
     }
     cyral = {
       source = "cyralinc/cyral"

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,12 @@ terraform {
   required_providers {
     okta = {
       source = "okta/okta"
-      version = "3.30.0"
+      # The Okta Provider version is being restricted to <= 3.30.0 due to a breaking 
+      # change introduced in 3.31.0. There's an issue registered in the Okta Provider 
+      # repository reporting this (https://github.com/okta/terraform-provider-okta/issues/1202).
+      # Once this issue gets fixed, we can update the version constraint back to "~> 3.17",
+      # so that the module can use the latest version of the Okta Provider.
+      version = "~> 3.17, <= 3.30.0"
     }
     cyral = {
       source = "cyralinc/cyral"


### PR DESCRIPTION
The Okta Provider version `3.31.0` introduces breaking changes that cause this module to fail when trying to create the Okta App resource (okta_app_saml) in an Okta org using a Classic Engine, [requiring an upgrade to the new Okta Identity Engine](https://help.okta.com/oie/en-us/Content/Topics/identity-engine/oie-upgrade-eligibility.htm).

An effective solution for now, is to pin the Okta Provider version to `<= 3.30.0`, so that this module doesn’t get impacted by this change on the Okta side. 

Once [this backward compatibility issue](https://github.com/okta/terraform-provider-okta/issues/1202) is fixed, we can go back to upgrade the Okta Provider version.