### PR TITLE
ENG-8908: Pin Okta Provider version to <= 3.30.0 (Backport to v2.1.x)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .terraform
 .terraform.lock.hcl
 terraform.tfstate*
+
+# Folder to manually test the module
+test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Minimum required Control Plane version: `v2.25.0`.
 
 ### Bug fix:
 
-* Pin Okta Provider version to `<= 3.30.0` ([#15](https://github.com/cyralinc/terraform-okta-idp/pull/15))
+* Pin Okta Provider version to `<= 3.30.0` ([#16](https://github.com/cyralinc/terraform-okta-idp/pull/16))
 
 ## 2.1.1 - (March 30, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 2.1.2 - (July 12, 2022)
+
+Minimum required Control Plane version: `v2.25.0`.
+
+### Bug fix:
+
+* Pin Okta Provider version to `<= 3.30.0` ([#15](https://github.com/cyralinc/terraform-okta-idp/pull/15))
+
 ## 2.1.1 - (March 30, 2022)
 
 Minimum required Control Plane version: `v2.25.0`.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ terraform {
   required_providers {
     okta = {
       source = "okta/okta"
-      version = "~> 3.17"
+      version = "~> 3.17, <= 3.30.0"
     }
     cyral = {
       source = "cyralinc/cyral"
@@ -67,7 +67,7 @@ output "okta_app_saml_id" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_cyral"></a> [cyral](#requirement\_cyral) | >= 2.2.0 |
-| <a name="requirement_okta"></a> [okta](#requirement\_okta) | ~> 3.17 |
+| <a name="requirement_okta"></a> [okta](#requirement\_okta) | ~> 3.17, <= 3.30.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.1.0 |
 
 ## Providers
@@ -75,7 +75,7 @@ output "okta_app_saml_id" {
 | Name | Version |
 |------|---------|
 | <a name="provider_cyral"></a> [cyral](#provider\_cyral) | >= 2.2.0 |
-| <a name="provider_okta"></a> [okta](#provider\_okta) | ~> 3.17 |
+| <a name="provider_okta"></a> [okta](#provider\_okta) | ~> 3.17, <= 3.30.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.1.0 |
 
 ## Modules

--- a/examples/basic-config/versions.tf
+++ b/examples/basic-config/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     okta = {
       source = "okta/okta"
-      version = "~> 3.17"
+      version = "~> 3.17, <= 3.30.0"
     }
     cyral = {
       source = "cyralinc/cyral"

--- a/examples/full-config/versions.tf
+++ b/examples/full-config/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     okta = {
       source = "okta/okta"
-      version = "~> 3.17"
+      version = "~> 3.17, <= 3.30.0"
     }
     cyral = {
       source = "cyralinc/cyral"

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,12 @@ terraform {
   required_providers {
     okta = {
       source = "okta/okta"
-      version = "~> 3.17"
+      # The Okta Provider version is being restricted to <= 3.30.0 due to a breaking 
+      # change introduced in 3.31.0. There's an issue registered in the Okta Provider 
+      # repository reporting this (https://github.com/okta/terraform-provider-okta/issues/1202).
+      # Once this issue gets fixed, we can update the version constraint back to "~> 3.17",
+      # so that the module can use the latest version of the Okta Provider.
+      version = "~> 3.17, <= 3.30.0"
     }
     cyral = {
       source = "cyralinc/cyral"


### PR DESCRIPTION
ENG-8908: Pin Okta Provider version to <= 3.30.0 (Backport to v2.1.x)

This is a backport of the fix done in the PR #15, to versions v2.1.x. It intends to cut a new patch `v2.1.2` for this module.