### PR TITLE
feat: Update Okta module to use Generic SAML instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ terraform {
   required_providers {
     okta = {
       source = "okta/okta"
-      version = "~> 3.17, <= 3.30.0"
+      version = "~> 3.17"
     }
     cyral = {
       source = "cyralinc/cyral"
-      version = ">= 2.2.0"
+      version = "~> 4.3"
     }
     random = {
       source = "hashicorp/random"
@@ -43,8 +43,6 @@ module "cyral_idp_okta" {
   source = "cyralinc/idp/okta"
   version = ">= 3.0.0"
 
-  control_plane = "mytenant.cyral.com:8000"
-  
   okta_app_name = "Cyral"
   okta_groups = ["Everyone"]
   
@@ -66,17 +64,17 @@ output "okta_app_saml_id" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_cyral"></a> [cyral](#requirement\_cyral) | >= 2.2.0 |
-| <a name="requirement_okta"></a> [okta](#requirement\_okta) | ~> 3.17, <= 3.30.0 |
+| <a name="requirement_cyral"></a> [cyral](#requirement\_cyral) | >= 4.3.0 |
+| <a name="requirement_okta"></a> [okta](#requirement\_okta) | 3.46.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.1.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_cyral"></a> [cyral](#provider\_cyral) | >= 2.2.0 |
-| <a name="provider_okta"></a> [okta](#provider\_okta) | ~> 3.17, <= 3.30.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | >= 3.1.0 |
+| <a name="provider_cyral"></a> [cyral](#provider\_cyral) | 4.3.0 |
+| <a name="provider_okta"></a> [okta](#provider\_okta) | 3.46.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.5.1 |
 
 ## Modules
 
@@ -86,28 +84,23 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [cyral_integration_idp_okta.this](https://registry.terraform.io/providers/cyralinc/cyral/latest/docs/resources/integration_idp_okta) | resource |
-| [okta_app_group_assignments.this](https://registry.terraform.io/providers/okta/okta/latest/docs/resources/app_group_assignments) | resource |
-| [okta_app_saml.this](https://registry.terraform.io/providers/okta/okta/latest/docs/resources/app_saml) | resource |
+| [cyral_integration_idp_saml.this](https://registry.terraform.io/providers/cyralinc/cyral/latest/docs/resources/integration_idp_saml) | resource |
+| [cyral_integration_idp_saml_draft.this](https://registry.terraform.io/providers/cyralinc/cyral/latest/docs/resources/integration_idp_saml_draft) | resource |
+| [okta_app_group_assignments.this](https://registry.terraform.io/providers/okta/okta/3.46.0/docs/resources/app_group_assignments) | resource |
+| [okta_app_saml.this](https://registry.terraform.io/providers/okta/okta/3.46.0/docs/resources/app_saml) | resource |
 | [random_uuid.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/uuid) | resource |
 | [cyral_saml_certificate.this](https://registry.terraform.io/providers/cyralinc/cyral/latest/docs/data-sources/saml_certificate) | data source |
 | [cyral_saml_configuration.this](https://registry.terraform.io/providers/cyralinc/cyral/latest/docs/data-sources/saml_configuration) | data source |
-| [okta_group.this](https://registry.terraform.io/providers/okta/okta/latest/docs/data-sources/group) | data source |
+| [okta_group.this](https://registry.terraform.io/providers/okta/okta/3.46.0/docs/data-sources/group) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_allowed_clock_skew"></a> [allowed\_clock\_skew](#input\_allowed\_clock\_skew) | Clock skew in seconds that is tolerated when validating Identity Provider tokens. | `number` | If not set, the default value will be retrieved from the Okta Application SAML metadata. | no |
-| <a name="input_back_channel_logout"></a> [back\_channel\_logout](#input\_back\_channel\_logout) | Indicates whether or not the Okta Identity Provider supports backchannel logout. | `bool` | If not set, the default value will be retrieved from the Okta Application SAML metadata. | no |
-| <a name="input_control_plane"></a> [control\_plane](#input\_control\_plane) | Control plane host and API port (ex: some-cp.cyral.com:8000). | `string` | n/a | yes |
-| <a name="input_disable_force_authentication"></a> [disable\_force\_authentication](#input\_disable\_force\_authentication) | Indicates whether the Okta Identity Provider must authenticate the presenter directly rather than rely on a previous security context. | `bool` | If not set, the default value will be retrieved from the Okta Application SAML metadata. | no |
 | <a name="input_idp_integration_name"></a> [idp\_integration\_name](#input\_idp\_integration\_name) | IdP integration name that will be shown in Control Plane. | `string` | n/a | yes |
 | <a name="input_okta_app_name"></a> [okta\_app\_name](#input\_okta\_app\_name) | The name of the Okta Application that will be created. | `string` | n/a | yes |
 | <a name="input_okta_groups"></a> [okta\_groups](#input\_okta\_groups) | Groups that will be assigned in the Okta Application. | `list(string)` | `[]` | no |
-| <a name="input_okta_groups_filter"></a> [okta\_groups\_filter](#input\_okta\_groups\_filter) | The type and value of the filter that will be applied to Okta groups. | <pre>object({<br>    type = string<br>    value = string<br>  })</pre> | <pre>{<br>  "type": "REGEX",<br>  "value": ".*"<br>}</pre> | no |
-| <a name="input_tenant"></a> [tenant](#input\_tenant) | Tenant associated with the Control Plane. | `string` | `"default"` | no |
-| <a name="input_wants_assertions_encrypted"></a> [wants\_assertions\_encrypted](#input\_wants\_assertions\_encrypted) | Indicates whether the Cyral Service Provider expects an encrypted assertion. | `bool` | If not set, the default value will be retrieved from the Okta Application SAML metadata. | no |
+| <a name="input_okta_groups_filter"></a> [okta\_groups\_filter](#input\_okta\_groups\_filter) | The type and value of the filter that will be applied to Okta groups. | <pre>object({<br>    type  = string<br>    value = string<br>  })</pre> | <pre>{<br>  "type": "REGEX",<br>  "value": ".*"<br>}</pre> | no |
 
 ## Outputs
 

--- a/examples/basic-config/main.tf
+++ b/examples/basic-config/main.tf
@@ -1,10 +1,10 @@
 provider "cyral" {
   # client_id and client_secret may also be declared as env vars.
   # Please see provider docs for more info.
-  client_id = ""
+  client_id     = ""
   client_secret = ""
 
-  control_plane = "mytenant.cyral.com:8000"
+  control_plane = "mytenant.cyral.com"
 }
 
 provider "okta" {
@@ -14,10 +14,10 @@ provider "okta" {
 }
 
 module "cyral_idp_okta" {
-  source = "cyralinc/idp/okta"
+  source  = "cyralinc/idp/okta"
   version = ">= 3.0.0"
-  
+
   okta_app_name = "Cyral"
-  
+
   idp_integration_name = "Okta"
 }

--- a/examples/basic-config/main.tf
+++ b/examples/basic-config/main.tf
@@ -16,8 +16,6 @@ provider "okta" {
 module "cyral_idp_okta" {
   source = "cyralinc/idp/okta"
   version = ">= 3.0.0"
-
-  control_plane = "mytenant.cyral.com:8000"
   
   okta_app_name = "Cyral"
   

--- a/examples/basic-config/versions.tf
+++ b/examples/basic-config/versions.tf
@@ -1,15 +1,15 @@
 terraform {
   required_providers {
     okta = {
-      source = "okta/okta"
-      version = "~> 3.17, <= 3.30.0"
+      source  = "okta/okta"
+      version = "~> 3.17"
     }
     cyral = {
-      source = "cyralinc/cyral"
-      version = ">= 2.2.0"
+      source  = "cyralinc/cyral"
+      version = "~> 4.3"
     }
     random = {
-      source = "hashicorp/random"
+      source  = "hashicorp/random"
       version = ">= 3.1.0"
     }
   }

--- a/examples/full-config/main.tf
+++ b/examples/full-config/main.tf
@@ -1,7 +1,7 @@
 provider "cyral" {
   # client_id and client_secret may also be declared as env vars.
   # Please see provider docs for more info.
-  client_id = ""
+  client_id     = ""
   client_secret = ""
 
   control_plane = "mytenant.cyral.com:8000"
@@ -14,22 +14,15 @@ provider "okta" {
 }
 
 module "cyral_idp_okta" {
-  source = "cyralinc/idp/okta"
+  source  = "cyralinc/idp/okta"
   version = ">= 3.0.0"
 
-  control_plane = "mytenant.cyral.com:8000"
-  tenant = "default"
-  
   okta_app_name = "Cyral"
-  okta_groups = ["Everyone"]
+  okta_groups   = ["Everyone"]
   okta_groups_filter = {
-    type = "REGEX"
+    type  = "REGEX"
     value = "(Dev)|(Admin)"
   }
 
   idp_integration_name = "Okta"
-  back_channel_logout = false
-  wants_assertions_encrypted = false
-  disable_force_authentication = true
-  allowed_clock_skew = 0
 }

--- a/examples/full-config/main.tf
+++ b/examples/full-config/main.tf
@@ -4,7 +4,7 @@ provider "cyral" {
   client_id     = ""
   client_secret = ""
 
-  control_plane = "mytenant.cyral.com:8000"
+  control_plane = "mytenant.cyral.com"
 }
 
 provider "okta" {

--- a/examples/full-config/versions.tf
+++ b/examples/full-config/versions.tf
@@ -1,15 +1,15 @@
 terraform {
   required_providers {
     okta = {
-      source = "okta/okta"
-      version = "~> 3.17, <= 3.30.0"
+      source  = "okta/okta"
+      version = "~> 3.17"
     }
     cyral = {
-      source = "cyralinc/cyral"
-      version = ">= 2.2.0"
+      source  = "cyralinc/cyral"
+      version = "~> 4.3"
     }
     random = {
-      source = "hashicorp/random"
+      source  = "hashicorp/random"
       version = ">= 3.1.0"
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -2,20 +2,12 @@ resource "random_uuid" "this" {
 }
 
 locals {
-  sp_entity_id_endpoint = format(
-    "https://%s/auth/realms/%s",
-    var.control_plane, var.tenant
-  )
-  idp_integration_alias = format("okta.%s", random_uuid.this.result)
-  sp_initiated_sso_endpoint = format(
-    "%s/broker/%s/endpoint",
-    local.sp_entity_id_endpoint, local.idp_integration_alias
-  )
-  idp_initiated_sso_endpoint = format(
-    "%s/clients/%s-client",
-    local.sp_initiated_sso_endpoint, local.idp_integration_alias
-  )
-  config = data.cyral_saml_configuration.this
+  idp_initiated_sso_endpoint = element(flatten([
+    for obj in cyral_integration_idp_saml_draft.this.service_provider_metadata : obj.assertion_consumer_services[*].url
+  ]), 0)
+  sp_entity_id_endpoint     = element(cyral_integration_idp_saml_draft.this.service_provider_metadata.*.entity_id, 0)
+  sp_initiated_sso_endpoint = element(cyral_integration_idp_saml_draft.this.service_provider_metadata.*.single_logout_url, 0)
+  config                    = data.cyral_saml_configuration.this
 }
 
 data "cyral_saml_certificate" "this" {
@@ -24,55 +16,55 @@ data "cyral_saml_certificate" "this" {
 resource "okta_app_saml" "this" {
   label = var.okta_app_name
 
-  sso_url = local.idp_initiated_sso_endpoint
-  recipient = local.idp_initiated_sso_endpoint
-  destination = local.idp_initiated_sso_endpoint
-  audience = local.sp_entity_id_endpoint
+  sso_url       = local.idp_initiated_sso_endpoint
+  recipient     = local.idp_initiated_sso_endpoint
+  destination   = local.idp_initiated_sso_endpoint
+  audience      = local.sp_entity_id_endpoint
   acs_endpoints = [local.idp_initiated_sso_endpoint, local.sp_initiated_sso_endpoint]
 
   subject_name_id_template = "$${user.userName}"
-  subject_name_id_format = "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"
-  response_signed = true
-  signature_algorithm = "RSA_SHA256"
-  digest_algorithm = "SHA256"
-  honor_force_authn = true
+  subject_name_id_format   = "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"
+  response_signed          = true
+  signature_algorithm      = "RSA_SHA256"
+  digest_algorithm         = "SHA256"
+  honor_force_authn        = true
   authn_context_class_ref  = "urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport"
 
   assertion_signed = true
-  sp_issuer = local.sp_entity_id_endpoint
+  sp_issuer        = local.sp_entity_id_endpoint
 
-  single_logout_issuer = local.sp_entity_id_endpoint
-  single_logout_url = local.sp_initiated_sso_endpoint
+  single_logout_issuer      = local.sp_entity_id_endpoint
+  single_logout_url         = local.sp_initiated_sso_endpoint
   single_logout_certificate = data.cyral_saml_certificate.this.certificate
 
   attribute_statements {
-    name = "EMAIL"
-    type = "EXPRESSION"
-    values = ["user.email"]
+    name      = "EMAIL"
+    type      = "EXPRESSION"
+    values    = ["user.email"]
     namespace = "urn:oasis:names:tc:SAML:2.0:attrname-format:basic"
   }
 
   attribute_statements {
-    name = "FIRST_NAME"
-    type = "EXPRESSION"
-    values = ["user.firstName"]
+    name      = "FIRST_NAME"
+    type      = "EXPRESSION"
+    values    = ["user.firstName"]
     namespace = "urn:oasis:names:tc:SAML:2.0:attrname-format:basic"
   }
 
   attribute_statements {
-    name = "LAST_NAME"
-    type = "EXPRESSION"
-    values = ["user.lastName"]
+    name      = "LAST_NAME"
+    type      = "EXPRESSION"
+    values    = ["user.lastName"]
     namespace = "urn:oasis:names:tc:SAML:2.0:attrname-format:basic"
   }
 
   attribute_statements {
-    name = "groups"
-    type = "GROUP"
-    filter_type = var.okta_groups_filter.type
+    name         = "groups"
+    type         = "GROUP"
+    filter_type  = var.okta_groups_filter.type
     filter_value = var.okta_groups_filter.value
-    values = []
-    namespace = "urn:oasis:names:tc:SAML:2.0:attrname-format:basic"
+    values       = []
+    namespace    = "urn:oasis:names:tc:SAML:2.0:attrname-format:basic"
   }
 
   lifecycle {
@@ -89,12 +81,12 @@ resource "okta_app_saml" "this" {
 
 data "okta_group" "this" {
   for_each = toset(var.okta_groups)
-  name = each.key
+  name     = each.key
 }
 
 resource "okta_app_group_assignments" "this" {
-  count = length(var.okta_groups) > 0 ? 1 : 0
-  app_id   = okta_app_saml.this.id
+  count  = length(var.okta_groups) > 0 ? 1 : 0
+  app_id = okta_app_saml.this.id
   dynamic "group" {
     for_each = toset([for g in data.okta_group.this : g.id])
     content {
@@ -107,33 +99,16 @@ data "cyral_saml_configuration" "this" {
   base_64_saml_metadata_document = base64encode(okta_app_saml.this.metadata)
 }
 
-resource "cyral_integration_idp_okta" "this" {
-  draft_alias = local.idp_integration_alias
-  samlp {
-    display_name = var.idp_integration_name
-    config {
-      single_sign_on_service_url = local.config.single_sign_on_service_url
-      single_logout_service_url = local.config.single_logout_service_url == "" ? null : local.config.single_logout_service_url
-      disable_using_jwks_url = local.config.disable_using_jwks_url
-      sync_mode = local.config.sync_mode == "" ? null : local.config.sync_mode
-      name_id_policy_format = local.config.name_id_policy_format == "" ? null : local.config.name_id_policy_format
-      principal_type = local.config.principal_type == "" ? null : local.config.principal_type
-      signature_type = local.config.signature_type == "" ? null : local.config.signature_type
-      saml_xml_key_name_tranformer = local.config.saml_xml_key_name_tranformer == "" ? null : local.config.saml_xml_key_name_tranformer
-      hide_on_login_page = local.config.hide_on_login_page
-      back_channel_supported = var.back_channel_logout == null ? local.config.back_channel_supported : var.back_channel_logout
-      disable_post_binding_response = local.config.disable_post_binding_response
-      disable_post_binding_authn_request = local.config.disable_post_binding_authn_request
-      disable_post_binding_logout = local.config.disable_post_binding_logout
-      want_assertions_encrypted = var.wants_assertions_encrypted == null ? local.config.want_assertions_encrypted : var.wants_assertions_encrypted
-      disable_force_authentication = var.disable_force_authentication == null ? local.config.disable_force_authentication : var.disable_force_authentication
-      gui_order = local.config.gui_order == "" ? null : local.config.gui_order
-      xml_sig_key_info_key_name_transformer = local.config.xml_sig_key_info_key_name_transformer == "" ? null : local.config.xml_sig_key_info_key_name_transformer
-      signing_certificate = local.config.signing_certificate == "" ? null : local.config.signing_certificate
-      allowed_clock_skew = var.allowed_clock_skew == null ? local.config.allowed_clock_skew : var.allowed_clock_skew
-      saml_metadata_url = local.config.saml_metadata_url == "" ? null : local.config.saml_metadata_url
-      base_64_saml_metadata_document = local.config.base_64_saml_metadata_document == "" ? null : local.config.base_64_saml_metadata_document
-      ldap_group_attribute = local.config.ldap_group_attribute == "" ? null : local.config.ldap_group_attribute
-    }
-  }
+resource "cyral_integration_idp_saml_draft" "this" {
+  display_name                = var.idp_integration_name
+  idp_type                    = "okta"
+  disable_idp_initiated_login = false
+}
+
+resource "cyral_integration_idp_saml" "this" {
+  saml_draft_id = cyral_integration_idp_saml_draft.this.id
+  # This is the IdP metadata document. You may choose instead to
+  # provide the url for the metadata XML document using
+  # the argument `idp_metadata_url`.
+  idp_metadata_xml = local.config.base_64_saml_metadata_document
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,9 +1,9 @@
 output "integration_idp_okta_id" {
   description = "The ID (Alias) of the Okta IdP Integration resource."
-  value = cyral_integration_idp_okta.this.id
+  value       = cyral_integration_idp_saml.this.id
 }
 
 output "okta_app_saml_id" {
   description = "The ID of the Okta SAML Application resource."
-  value = okta_app_saml.this.id
+  value       = okta_app_saml.this.id
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,62 +1,27 @@
-variable "tenant" {
-  type = string
-  description = "Tenant associated with the Control Plane."
-  default = "default"
-}
-
-variable "control_plane" {
-  type = string
-  description = "Control plane host and API port (ex: some-cp.cyral.com:8000)."
-}
-
 variable "idp_integration_name" {
-  type = string
+  type        = string
   description = "IdP integration name that will be shown in Control Plane."
 }
 
-variable "back_channel_logout" {
-  type = bool
-  description = "Indicates whether or not the Okta Identity Provider supports backchannel logout."
-  default = null
-}
-
-variable "wants_assertions_encrypted" {
-  type = bool
-  description = "Indicates whether the Cyral Service Provider expects an encrypted assertion."
-  default = null
-}
-
-variable "disable_force_authentication" {
-  type = bool
-  description = "Indicates whether the Okta Identity Provider must authenticate the presenter directly rather than rely on a previous security context."
-  default = null
-}
-
-variable "allowed_clock_skew" {
-  type = number
-  description = "Clock skew in seconds that is tolerated when validating Identity Provider tokens."
-  default = null
-}
-
 variable "okta_groups" {
-  type = list(string)
+  type        = list(string)
   description = "Groups that will be assigned in the Okta Application."
-  default = []
+  default     = []
 }
 
 variable "okta_app_name" {
-  type = string
+  type        = string
   description = "The name of the Okta Application that will be created."
 }
 
 variable "okta_groups_filter" {
   type = object({
-    type = string
+    type  = string
     value = string
   })
   description = "The type and value of the filter that will be applied to Okta groups."
   default = {
-    type = "REGEX"
+    type  = "REGEX"
     value = ".*"
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,20 +1,15 @@
 terraform {
   required_providers {
     okta = {
-      source = "okta/okta"
-      # The Okta Provider version is being restricted to <= 3.30.0 due to a breaking 
-      # change introduced in 3.31.0. There's an issue registered in the Okta Provider 
-      # repository reporting this (https://github.com/okta/terraform-provider-okta/issues/1202).
-      # Once this issue gets fixed, we can update the version constraint back to "~> 3.17",
-      # so that the module can use the latest version of the Okta Provider.
-      version = "~> 3.17, <= 3.30.0"
+      source  = "okta/okta"
+      version = "3.46.0"
     }
     cyral = {
       source = "cyralinc/cyral"
       version = ">= 2.2.0"
     }
     random = {
-      source = "hashicorp/random"
+      source  = "hashicorp/random"
       version = ">= 3.1.0"
     }
   }

--- a/versions.tf
+++ b/versions.tf
@@ -2,11 +2,11 @@ terraform {
   required_providers {
     okta = {
       source  = "okta/okta"
-      version = "3.46.0"
+      version = "~> 3.17"
     }
     cyral = {
-      source = "cyralinc/cyral"
-      version = ">= 2.2.0"
+      source  = "cyralinc/cyral"
+      version = "~> 4.3"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
As our API evolves, creating an okta integration via `cyral_integration_idp_okta` is now deprecated. In this PR we update the Okta module to use the generic SAML resource instead. 


This PR is blocked by:
- https://github.com/cyralinc/terraform-provider-cyral/pull/394

Note: We need to merge the PR above first, then cut a release in `cyral terraform provider`, so we can bump the versions file from this PR accordingly.