### PR TITLE
fix: Fix SSO Groups not being propagated + Remove deprecated field groups

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -59,7 +59,7 @@ resource "okta_app_saml" "this" {
   }
 
   attribute_statements {
-    name         = "groups"
+    name         = "memberOf"
     type         = "GROUP"
     filter_type  = var.okta_groups_filter.type
     filter_value = var.okta_groups_filter.value
@@ -72,9 +72,6 @@ resource "okta_app_saml" "this" {
       # This is needed because Okta stores the certificate with line breaks, which would cause
       # a plan at every apply
       single_logout_certificate,
-      # This is needed because Okta still updating `groups` field even though its 
-      # deprecated.
-      groups,
     ]
   }
 }


### PR DESCRIPTION
New terraform provider creates Okta integrations in the control plane using Generic SAML APIs, due to that the group parameter in the SAML assertion is populated by default with the value memberOf

However, the Okta application at Okta propagates the groups' information through the groups SAML parameter.

The mismatch above leads the SSO groups to not be propagated from Okta to the Control Plane.