### PR TITLE
ENG-12705: Fix attributes names in Okta app saml

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -38,21 +38,21 @@ resource "okta_app_saml" "this" {
   single_logout_certificate = data.cyral_saml_certificate.this.certificate
 
   attribute_statements {
-    name      = "EMAIL"
+    name      = "email"
     type      = "EXPRESSION"
     values    = ["user.email"]
     namespace = "urn:oasis:names:tc:SAML:2.0:attrname-format:basic"
   }
 
   attribute_statements {
-    name      = "FIRST_NAME"
+    name      = "firstName"
     type      = "EXPRESSION"
     values    = ["user.firstName"]
     namespace = "urn:oasis:names:tc:SAML:2.0:attrname-format:basic"
   }
 
   attribute_statements {
-    name      = "LAST_NAME"
+    name      = "lastName"
     type      = "EXPRESSION"
     values    = ["user.lastName"]
     namespace = "urn:oasis:names:tc:SAML:2.0:attrname-format:basic"


### PR DESCRIPTION
We notice the names were not matching with current Generic SAML integration default values. This PR fixes that

JIRA TICKET: [ENG-12705](https://cyralinc.atlassian.net/browse/ENG-12705)

[ENG-12705]: https://cyralinc.atlassian.net/browse/ENG-12705?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ